### PR TITLE
Revert 4310c3fcc1e6c11978b05c1ee431030879bd983f

### DIFF
--- a/datacube_query/utils.py
+++ b/datacube_query/utils.py
@@ -386,6 +386,9 @@ def write_geotiff(dataset, filename, time_index=None, profile_override=None, ove
             else:
                 data = data.isel(time=time_index).data
 
+            if isinstance(data, dask.array.Array):
+                data = data.compute()
+
             dest.write(data, bandnum)
 
 


### PR DESCRIPTION
Not calling `compute()` on dask arrays is hanging the plugin on the NCI.